### PR TITLE
AutoTranspose Functionality

### DIFF
--- a/config.hpp
+++ b/config.hpp
@@ -52,6 +52,15 @@ namespace midi {
         void validate() const;
     };
 
+    struct AutoTranspose {
+        bool ENABLED = false;
+        std::string TRANSPOSE_UP_KEY = "VK_UP";   // Default to Up Arrow
+        std::string TRANSPOSE_DOWN_KEY = "VK_DOWN"; // Default to Down Arrow
+
+        void validate() const;
+    };
+
+
     struct UISettings {
         bool alwaysOnTop = false;
     };
@@ -78,7 +87,7 @@ namespace midi {
     struct PlaybackSettings {
         VelocityCurveType velocityCurve = VelocityCurveType::LinearCoarse;
         NoteHandlingMode noteHandlingMode = NoteHandlingMode::LIFO;
-        std::vector<CustomVelocityCurve> customVelocityCurves; 
+        std::vector<CustomVelocityCurve> customVelocityCurves;
         void validate() const;
     };
 
@@ -88,6 +97,7 @@ namespace midi {
         PlaybackSettings playback;
         VolumeSettings volume;
         LegitModeSettings legit_mode;
+        AutoTranspose auto_transpose;
         HotkeySettings hotkeys;
         UISettings ui;
         std::map<std::string, std::map<std::string, std::string>> key_mappings;
@@ -120,6 +130,8 @@ namespace midi {
     void from_json(const nlohmann::json& j, VolumeSettings& v);
     void to_json(nlohmann::json& j, const LegitModeSettings& l);
     void from_json(const nlohmann::json& j, LegitModeSettings& l);
+    void to_json(nlohmann::json& j, const AutoTranspose& l);
+    void from_json(const nlohmann::json& j, AutoTranspose& l);
     void to_json(nlohmann::json& j, const MIDISettings& m);
     void from_json(const nlohmann::json& j, MIDISettings& m);
     void to_json(nlohmann::json& j, const HotkeySettings& h);


### PR DESCRIPTION
Added AutoTranspose, a feature that automatically adjusts transposition before playing a song. Instead of manually spamming the up/down arrows every time, the program now sets the suggested transposition for you.

This makes life easier for degenerates (like me) who just want to sit back and let the piano play without the extra hassle.

Since transposition is ultimately personal preference, this setting is disabled by default—but for those who want a seamless experience, just turn it on and enjoy!

NOTE: this was only tested on ROBLOX pianos. If the keybind is incorrect or it doesn't work, I did allow for the transposition keys to be changed in the settings.

Also fixed some incorrect indentation, and other minor issues.